### PR TITLE
Fix deprecation warning thrown in Atom 1.13

### DIFF
--- a/lib/status-bar.coffee
+++ b/lib/status-bar.coffee
@@ -62,6 +62,7 @@ class StatusBar extends View
       else if item.constructor.name is "TextEditor"
         mapping = atom.config.get('termination.core.mapTerminalsTo')
         return if mapping is 'None'
+        return unless item.getPath()
 
         switch mapping
           when 'File'
@@ -72,9 +73,8 @@ class StatusBar extends View
         prevTerminal = @getActiveTerminalView()
         if prevTerminal != nextTerminal
           if not nextTerminal?
-            if item.getTitle() isnt 'untitled'
-              if atom.config.get('termination.core.mapTerminalsToAutoOpen')
-                nextTerminal = @createTerminalView()
+            if atom.config.get('platformio-ide-terminal.core.mapTerminalsToAutoOpen')
+              nextTerminal = @createTerminalView()
           else
             @setActiveTerminalView(nextTerminal)
             nextTerminal.toggle() if prevTerminal?.panel.isVisible()

--- a/lib/status-bar.coffee
+++ b/lib/status-bar.coffee
@@ -73,7 +73,7 @@ class StatusBar extends View
         prevTerminal = @getActiveTerminalView()
         if prevTerminal != nextTerminal
           if not nextTerminal?
-            if atom.config.get('platformio-ide-terminal.core.mapTerminalsToAutoOpen')
+            if atom.config.get('termination.core.mapTerminalsToAutoOpen')
               nextTerminal = @createTerminalView()
           else
             @setActiveTerminalView(nextTerminal)


### PR DESCRIPTION
Here ya go, this will fix #20.

`item.getPath()` returns undefined, causing `path.dirname` to throw a warning.  