### PR TITLE
Fix wqPane.addItem usage

### DIFF
--- a/lib/status-bar.coffee
+++ b/lib/status-bar.coffee
@@ -395,7 +395,7 @@ class StatusBar extends View
     @statusContainer.children().eq(fromIndex).detach()
     view.statusIcon.removeTooltip()
 
-    pane.addItem view, pane.getItems().length
+    pane.addItem view, { index: pane.getItems().length }
     pane.activateItem view
 
     view.focus()


### PR DESCRIPTION
Pane::addItem(item, 1) is deprecated in favor of Pane::addItem(item, {index: 1})

Fixes #26