### PR TITLE
add bliss theme

### DIFF
--- a/lib/termination.coffee
+++ b/lib/termination.coffee
@@ -150,7 +150,8 @@ module.exports =
             'Christmas',
             'github',
             'one-dark',
-            'one-light'
+            'one-light',
+            'bliss'
           ]
     iconColors:
       type: 'object'

--- a/lib/themes/bliss.coffee
+++ b/lib/themes/bliss.coffee
@@ -1,0 +1,19 @@
+module.exports =
+  normal:
+    black: '#65737E'
+    red:'#bf616a'
+    green: '#a3be8c'
+    yellow: '#EBCB8B'
+    blue: '#8fa1b3'
+    magenta: '#b48ead'
+    cyan: '#96B5B4'
+    white: '#c0c5ce'
+  bright:
+    black: '#65737E'
+    red: '#bf616a'
+    green: '#a3be8c'
+    yellow: '#EBCB8B'
+    blue: '#8fa1b3'
+    magenta: '#b48ead'
+    cyan: '#96B5B4'
+    white: '#c0c5ce'

--- a/styles/themes.less
+++ b/styles/themes.less
@@ -18,4 +18,5 @@
   @import 'themes/github';
   @import 'themes/one-dark';
   @import 'themes/one-light';
+  @import 'themes/bliss';
 }

--- a/styles/themes/bliss.less
+++ b/styles/themes/bliss.less
@@ -1,0 +1,12 @@
+.bliss {
+  background-color: #2b303b;
+  color: #c0c5ce;
+
+  ::selection {
+    background-color: #4F5B66;
+  }
+
+  .terminal-cursor {
+    background-color: #c0c5ce;
+  }
+}


### PR DESCRIPTION
PR to add `Bliss`, which is a modified version of the popular base16-ocean color scheme.

Screenshot:

![screen shot 2017-06-10 at 2 57 21 pm](https://user-images.githubusercontent.com/5678694/27005472-5f2b17c6-4ded-11e7-8c57-67960a59c866.png)

Screenshot with Bliss UI + Bliss Syntax:

![screen shot 2017-06-10 at 3 36 42 pm](https://user-images.githubusercontent.com/5678694/27005730-a2ff25d2-4df2-11e7-93ed-775d275c4f34.png)
