### PR TITLE
adding gruvbox theme

### DIFF
--- a/lib/termination.coffee
+++ b/lib/termination.coffee
@@ -151,7 +151,8 @@ module.exports =
             'github',
             'one-dark',
             'one-light',
-            'bliss'
+            'bliss',
+            'gruvbox'
           ]
     iconColors:
       type: 'object'

--- a/lib/themes/gruvbox.coffee
+++ b/lib/themes/gruvbox.coffee
@@ -1,0 +1,19 @@
+module.exports =
+  normal:
+    black: '#282828'
+    red:'#cc241d'
+    green: '#98971a'
+    yellow: '#d79921'
+    blue: '#458588'
+    magenta: '#b16286'
+    cyan: '#8ec07c'
+    white: '#ebdbb2'
+  bright:
+    black: '#65737E'
+    red: '#bf616a'
+    green: '#a3be8c'
+    yellow: '#EBCB8B'
+    blue: '#8fa1b3'
+    magenta: '#b48ead'
+    cyan: '#96B5B4'
+    white: '#c0c5ce'

--- a/styles/themes.less
+++ b/styles/themes.less
@@ -19,4 +19,5 @@
   @import 'themes/one-dark';
   @import 'themes/one-light';
   @import 'themes/bliss';
+  @import 'themes/gruvbox';
 }

--- a/styles/themes/gruvbox.less
+++ b/styles/themes/gruvbox.less
@@ -1,0 +1,12 @@
+.gruvbox {
+  background-color: #282828;
+  color: #ebdbb2;
+
+  ::selection {
+    background-color: #ebdbb2;
+  }
+
+  .terminal-cursor {
+    background-color: #ebdbb2;
+  }
+}


### PR DESCRIPTION
Based on https://github.com/morhetz/gruvbox

there a corresponding Atom syntax theme already, so why not the terminal too?