### PR TITLE
Fix unchanged reference to PlatformIO

### DIFF
--- a/lib/view.coffee
+++ b/lib/view.coffee
@@ -71,7 +71,7 @@ class TerminationView extends View
     @xterm.on 'mouseup', (event) =>
       if event.which != 3
         text = window.getSelection().toString()
-        atom.clipboard.write(text) if atom.config.get('platformio-ide-terminal.toggles.selectToCopy') and text
+        atom.clipboard.write(text) if atom.config.get('termination.toggles.selectToCopy') and text
         unless text
           @focus()
     @xterm.on 'dragenter', override


### PR DESCRIPTION
Fixed unchanged reference to PlatformIO in `lib/view.coffee`. The key `platformio-ide-terminal.toggles.selectToCopy` was referenced, but it should probably be `termination.toggles.selectToCopy`