### PR TITLE
Auto-naming terminals

### DIFF
--- a/lib/status-bar.coffee
+++ b/lib/status-bar.coffee
@@ -213,7 +213,7 @@ class StatusBar extends View
     statusIcon = new StatusIcon()
     terminationView = new TerminationView(id, pwd, statusIcon, this, shell, args, env, autoRun)
     statusIcon.initialize(terminationView)
-    statusIcon.updateName currentDirectory + '/'
+    statusIcon.updateName currentDirectory + '/' if atom.config.get('termination.toggles.autoName')
 
     terminationView.attach()
 

--- a/lib/status-bar.coffee
+++ b/lib/status-bar.coffee
@@ -207,11 +207,13 @@ class StatusBar extends View
       else pwd = home
 
     id = editorPath or projectFolder or home
+    currentDirectory = if path.basename(id).indexOf('.') >= 0 then path.basename(path.dirname(id)) else path.basename(id)
     id = filePath: id, folderPath: path.dirname(id)
 
     statusIcon = new StatusIcon()
     terminationView = new TerminationView(id, pwd, statusIcon, this, shell, args, env, autoRun)
     statusIcon.initialize(terminationView)
+    statusIcon.updateName currentDirectory + '/'
 
     terminationView.attach()
 

--- a/lib/termination.coffee
+++ b/lib/termination.coffee
@@ -37,6 +37,12 @@ module.exports =
           description: 'Should the terminal close if the shell exits?'
           type: 'boolean'
           default: true
+        autoName:
+          title: 'Auto Name Terminal'
+          description: 'Should the terminal name itself based on the directory
+          of the current file open in your text editor?'
+          type: 'boolean'
+          default: true
         cursorBlink:
           title: 'Cursor Blink'
           description: 'Should the cursor blink when the terminal is active?'

--- a/lib/termination.coffee
+++ b/lib/termination.coffee
@@ -28,9 +28,6 @@ module.exports =
   consumeStatusBar: (statusBarProvider) ->
     @statusBarTile = new (require './status-bar')(statusBarProvider)
 
-  consumeTreeView: (treeView) ->
-    @selectedFiles = treeView.selectedPaths()
-
   config:
     toggles:
       type: 'object'

--- a/lib/termination.coffee
+++ b/lib/termination.coffee
@@ -1,6 +1,5 @@
 module.exports =
   statusBar: null
-  selectedFiles: null
 
   activate: ->
 

--- a/lib/termination.coffee
+++ b/lib/termination.coffee
@@ -1,5 +1,6 @@
 module.exports =
   statusBar: null
+  selectedFiles: null
 
   activate: ->
 
@@ -26,6 +27,9 @@ module.exports =
 
   consumeStatusBar: (statusBarProvider) ->
     @statusBarTile = new (require './status-bar')(statusBarProvider)
+
+  consumeTreeView: (treeView) ->
+    @selectedFiles = treeView.selectedPaths()
 
   config:
     toggles:

--- a/package.json
+++ b/package.json
@@ -57,6 +57,11 @@
       "versions": {
         "^1.0.0": "consumeStatusBar"
       }
+    },
+    "tree-view": {
+      "versions": {
+        "^1.0.0": "consumeTreeView"
+      }
     }
   },
   "providedServices": {

--- a/package.json
+++ b/package.json
@@ -57,11 +57,6 @@
       "versions": {
         "^1.0.0": "consumeStatusBar"
       }
-    },
-    "tree-view": {
-      "versions": {
-        "^1.0.0": "consumeTreeView"
-      }
     }
   },
   "providedServices": {


### PR DESCRIPTION
I was able to implement this feature rather simply, using a lot of existing calculations. However, terminals can now be automatically named to the nearest parent directory of the open file in the editor. If no file is open in the editor, the base of the project is used. This can be toggled in the settings, and the default behavior is to have auto-naming turned on.

This resolves issue #74 